### PR TITLE
Add case for arbitrary resolution in conflict resolver

### DIFF
--- a/src/ConflictResolver/conflict-resolver.ts
+++ b/src/ConflictResolver/conflict-resolver.ts
@@ -15,6 +15,8 @@ export class ConflictResolver {
         return this.merge(record, serverData);
       case "manual":
         return this.markForManualResolution(record, serverData);
+      case "arbitrary":
+         return this.markForSpecificResolution(record, serverData)
       default:
         return this.serverWins(record, serverData);
     }


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by DevzyAi -->
### Summary by DevzyAi

- Bug Fix: Updated conflict resolution so the “arbitrary” strategy now follows the intended specific-resolution flow instead of defaulting to server-wins behavior. This improves consistency and predictability when resolving conflicts, helping ensure records are handled according to the selected strategy and reducing unexpected outcomes during sync or merge operations.
<!-- end of auto-generated comment: release notes by DevzyAi -->