### PR TITLE
Add arbitrary resolution case to conflict resolver

### DIFF
--- a/src/ConflictResolver/conflict-resolver.ts
+++ b/src/ConflictResolver/conflict-resolver.ts
@@ -15,6 +15,8 @@ export class ConflictResolver {
         return this.merge(record, serverData);
       case "manual":
         return this.markForManualResolution(record, serverData);
+      case "arbitrary":
+        return this.markForArbitrary(record, serverData);
       default:
         return this.serverWins(record, serverData);
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new resolution path but the corresponding `markForArbitrary` implementation/type wiring is not present in the shown changes, which may cause runtime/compile failures when `"arbitrary"` is configured.
> 
> **Overview**
> `ConflictResolver.resolve()` now recognizes a new `"arbitrary"` `conflictResolution` value and routes it to `markForArbitrary(record, serverData)` instead of falling back to the default resolution behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e41327b93f7ee7c67a9b599869fc557f30d6f51b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- This is an auto-generated comment: release notes by DevzyAi -->
### Summary by DevzyAi

- New Feature: Added an “arbitrary” conflict-resolution option, allowing users to choose a strategy that resolves conflicts by selecting an arbitrary side when syncing or merging data. This provides an additional, explicit resolution mode for workflows where deterministic selection isn’t required, expanding available conflict-handling behavior without affecting existing strategies.
<!-- end of auto-generated comment: release notes by DevzyAi -->